### PR TITLE
Fixed missing deepClone for resource configuration

### DIFF
--- a/src/resource/resource-configuration.ts
+++ b/src/resource/resource-configuration.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { ResourceConfigurationOptions } from "./resource-configuration-options";
 import { ResourceInstance } from "./resource-instance";
 import { NegativeIntGenerator } from "./phantom-generator/negative-int-generator";
@@ -51,7 +52,11 @@ export function ResourceConfiguration(resourceOptions?: ResourceConfigurationOpt
              * Options for the resource.
              * @type {ResourceConfigurationOptions}
              */
-            options: ResourceConfigurationOptions = Object.assign({}, DEFAULT_RESOURCE_CONFIGURATION_OPTIONS, resourceOptions);
+            options: ResourceConfigurationOptions = Object.assign(
+                {}, 
+                cloneDeep(DEFAULT_RESOURCE_CONFIGURATION_OPTIONS), 
+                resourceOptions
+            );
 
         /*
          * Check if configurations are correct and throw error otherwise.


### PR DESCRIPTION
As ``DEFAULT_RESOURCE_CONFIGURATION_OPTIONS`` defines an empty array/list ``paramDefaults`` within its object, this array/list is re-used every time when we call 

```javascript
        options.paramDefaults.push(
            new ResourceParamDefaultFromPayload('pk', options.pkAttr)
        );
```

Therefore we need to deepcopy ``DEFAULT_RESOURCE_CONFIGURATION_OPTIONS`` using lodash.