### PR TITLE
Added action to publish package on NPM.js

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+
+    - name: Install dependencies
+      run: |
+        npm --no-git-tag-version version "${PACKAGE_VERSION/refs\/tags\/}"
+        npm install
+      env:
+        PACKAGE_VERSION: ${{ github.ref }}
+
+    - name: Build distribution package
+      run: |
+        npm run build
+
+    - name: Publish distribution package
+      working-directory: ./dist
+      run: |
+        npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        npm publish . --tag "${NPM_TAG}" --access "${NPM_ACCESS}" ${NPM_DRY_RUN:+--dry-run}
+      env:
+        NPM_TAG: latest
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_ACCESS: ${{ secrets.NPM_ACCESS }}
+        NPM_DRY_RUN: ${{ secrets.NPM_DRY_RUN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Angular version 10
+### Changed
+- Minimal required Angular version bumped to 8.0
+- Fix for inheriting action methods
 
 ## [1.0.0] - 2019-11-27
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-resource-factory",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Interact with RESTful APIs with advanced features as caches and data stores.",
   "main": "bundle/ngx-resource-factory.min.js",
   "module": "module.js",


### PR DESCRIPTION
Added a GitHub Actions workflow for publishing the package to NPM.js. The package is published as soon as a release gets created in GitHub. The version is take from the release tag name. Needs secrets as follows:
* `NPM_TOKEN`: Login token for NPM.js
* `NPM_ACCESS`: public or restricted
* `NPM_DRY_RUN`: Publishes with --dry-run if this secret is set